### PR TITLE
Updated regex for matching constants

### DIFF
--- a/src/dbupload/dbconn.py
+++ b/src/dbupload/dbconn.py
@@ -50,8 +50,8 @@ class DropboxConnection:
         home_src = self.browser.open('https://www.dropbox.com/home').read()
         
         try:
-            self.root_ns = re.findall(r"root_ns: (\d+)", home_src)[0]
-            self.token = re.findall(r"TOKEN: ['\"](.+?)['\"]", home_src)[0].decode('string_escape')
+            self.root_ns = re.findall(r"\"root_ns\": (\d+)", home_src)[0]
+            self.token = re.findall(r"\"TOKEN\": ['\"](.+?)['\"]", home_src)[0].decode('string_escape')
             
         except:
             raise(Exception("Unable to find constants for AJAX requests"))


### PR DESCRIPTION
In the new style constans are in a dictornary. Quotes must be added when matching. 

var Constants = {"work_root_ns": 0, "TOKEN": "lXcAra43qTL-6sjq1QQDhyKm" ...};
